### PR TITLE
feat: improve previously entered selection screens

### DIFF
--- a/docassemble/MLHStatutoryWill/data/questions/MichiganStatutoryWill.yml
+++ b/docassemble/MLHStatutoryWill/data/questions/MichiganStatutoryWill.yml
@@ -193,6 +193,15 @@ code: |
   x.complete = True
 ---
 code: |
+  spouse[i].entity_type = 'person'
+  spouse[i].name.first
+  if spouse[i] in giftee.elements:
+    spouse[i].us_address_yn
+    spouse[i].address.address
+    spouse[i].gift_amount
+  spouse[i].complete = True
+---
+code: |
   children[i].entity_type = 'person'
   children[i].name.first
   if children[i] in giftee.elements:
@@ -596,7 +605,7 @@ fields:
     datatype: object_radio
     none of the above: "(Someone else)"
     choices: |
-      (person for person in children.complete_elements() if person.entity_type == giftee[i].entity_type and person not in giftee.complete_elements())
+      (person for person in (*children.complete_elements(), *spouse.complete_elements()) if person.entity_type == giftee[i].entity_type and person not in giftee.complete_elements())
   - code: |
       giftee[i].name_fields(
         person_or_business=giftee[i].entity_type,
@@ -618,7 +627,7 @@ validation code: |
 ---
 id: children_or_giftee_us_address_yn
 generic object: ALPeopleList
-if: x is children or x is giftee
+if: x is spouse or x is children or x is giftee
 question: |
   You have named ${ x[i].name } as a cash gift recipient.
 fields:
@@ -632,7 +641,7 @@ validation code: |
 ---
 id: children_or_giftee_address
 generic object: ALPeopleList
-if: x is children or x is giftee
+if: x is spouse or x is children or x is giftee
 sets:
   - x[i].address.address
   - x[i].address.city
@@ -648,7 +657,7 @@ fields:
 id: gift_amount
 sets: x[i].gift_amount_in_words
 generic object: ALPeopleList
-if: x is children or x is giftee
+if: x is spouse or x is children or x is giftee
 question: |
   Cash gift amount
 subquestion: |
@@ -1307,15 +1316,10 @@ confirm: True
 table: giftee.table
 rows: giftee
 columns:
-  - Name: f'{row_item.name} {("(Child)" if row_item in children else "")}'
+  - Name: row_item.name
   - Address: row_item.address.on_one_line()
   - Gift Amount: currency(row_item.gift_amount)
-edit:
-  - entity_type
-  - name.first
-  - us_address_yn
-  - address.address
-  - gift_amount
+delete buttons: True
 show incomplete: True
 confirm: True
 ---

--- a/docassemble/MLHStatutoryWill/data/questions/MichiganStatutoryWill.yml
+++ b/docassemble/MLHStatutoryWill/data/questions/MichiganStatutoryWill.yml
@@ -592,13 +592,24 @@ question: |
   What is the name of the charity you want to receive the ${ ordinal(i) } cash gift?
   % endif
 fields:
-  - Someone previously entered?: giftee[i]
-    datatype: object
-    disable others: True
+  - no label: giftee[i]
+    datatype: object_radio
+    none of the above: "(Someone else)"
     choices: |
       (person for person in children.complete_elements() if person.entity_type == giftee[i].entity_type and person not in giftee.complete_elements())
   - code: |
-      giftee[i].name_fields(person_or_business=giftee[i].entity_type)
+      giftee[i].name_fields(
+        person_or_business=giftee[i].entity_type,
+        show_if=(
+          {"variable": "giftee[i]", "is": None}
+          if any(
+            person.entity_type == giftee[i].entity_type
+            and person not in giftee.complete_elements()
+            for person in children.complete_elements()
+          )
+          else None
+        ),
+      )
 validation code: |
   giftee[i].address.invalidate_attr("address")
   giftee[i].invalidate_attr("us_address_yn")
@@ -814,13 +825,24 @@ question: |
   Enter the name of the bank you want to be your ${ ordinal(i) } personal representative.
   % endif
 fields:
-  - Someone previously entered?: representatives[i]
-    datatype: object
-    disable others: True
+  - no label: representatives[i]
+    datatype: object_radio
+    none of the above: "(Someone else)"
     choices: |
       (person for person in (*guardians.complete_elements(), *conservators.complete_elements()) if person.entity_type == representatives[i].entity_type and person not in representatives.complete_elements())
   - code: |
-      representatives[i].name_fields(person_or_business=representatives[i].entity_type)
+      representatives[i].name_fields(
+        person_or_business=representatives[i].entity_type,
+        show_if=(
+          {"variable": "representatives[i]", "is": None}
+          if any(
+            person.entity_type == representatives[i].entity_type
+            and person not in representatives.complete_elements()
+            for person in (*guardians.complete_elements(), *conservators.complete_elements())
+          )
+          else None
+        ),
+      )
 ---
 sets:
   - representatives[i].address.address
@@ -874,13 +896,23 @@ sets:
 question: |
   Enter the full name of the person you would like to be the ${ ordinal(i) } guardian for your child.
 fields:
-  - Someone previously entered?: guardians[i]
-    datatype: object
-    disable others: True
+  - no label: guardians[i]
+    datatype: object_radio
+    none of the above: "(Someone else)"
     choices: |
       (person for person in (*representatives.complete_elements(), *conservators.complete_elements()) if person.entity_type == 'person' and person not in guardians.complete_elements())
   - code: |
-      guardians[i].name_fields()
+      guardians[i].name_fields(
+        show_if=(
+          {"variable": "guardians[i]", "is": None}
+          if any(
+            person.entity_type == 'person'
+            and person not in guardians.complete_elements()
+            for person in (*representatives.complete_elements(), *conservators.complete_elements())
+          )
+          else None
+        ),
+      )
 ---
 id: guardians_address
 sets:
@@ -946,13 +978,24 @@ question: |
   Enter the name of the bank you want to be your conservator.
   % endif
 fields:
-  - Someone previously entered?: conservators[i]
-    datatype: object
-    disable others: True
+  - no label: conservators[i]
+    datatype: object_radio
+    none of the above: "(Someone else)"
     choices: |
       (person for person in (*representatives.complete_elements(), *guardians.complete_elements()) if person.entity_type == conservators[i].entity_type and person not in conservators.complete_elements())
   - code: |
-      conservators[i].name_fields(person_or_business=conservators[i].entity_type)
+      conservators[i].name_fields(
+        person_or_business=conservators[i].entity_type,
+        show_if=(
+          {"variable": "conservators[i]", "is": None}
+          if any(
+            person.entity_type == conservators[i].entity_type
+            and person not in conservators.complete_elements()
+            for person in (*representatives.complete_elements(), *guardians.complete_elements())
+          )
+          else None
+        ),
+      )
 ---
 id: conservators_address
 sets:


### PR DESCRIPTION
This PR changes the screens that allow selecting a previously entered person or business by changing it into a radio selection. This makes it easier for users to see the previously entered person or business rather than it hiding behind the dropdown. This also makes it so that selecting a previously entered person or business hides the name fields rather than disabling them which should be clearer to the user.

<img width="532" height="795" alt="image" src="https://github.com/user-attachments/assets/294dc3da-60dc-4717-8ba6-0fcc39349ffe" />
